### PR TITLE
fix: Ensure slug is no longer than 59 chars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
     - id: slug
       shell: bash
       run: |
-        SLUG=$(echo -n "${BRANCH}" | sed -E 's/[^a-zA-Z0-9_]+/-/g' | sed -E 's/^-|-$//g' | tr '[:upper:]' '[:lower:]')
+        SLUG=$(echo -n "${BRANCH}" | sed -E 's/[^a-zA-Z0-9_]+/-/g' | sed -E 's/^-|-$//g' | tr '[:upper:]' '[:lower:]' | cut -c1-59)
         echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
       env:
         BRANCH: ${{ inputs.branch }}


### PR DESCRIPTION
We use 59 instead of 63 to allow for FluxCD to add the "env-" prefix (59+4=63; 63 is the max length of a Kubernetes resource.)